### PR TITLE
Make 'Programming Pins' more consistent with programmer schematic

### DIFF
--- a/src/chips.js
+++ b/src/chips.js
@@ -107,7 +107,8 @@ const chips = [
         pins: {
           ICPCK: "PA3",
           ICPDA: "PA6",
-          RESET: "PA5"
+          ICVPP: "PA5",
+          ICVDD: "VDD"
         }
       }
     }
@@ -222,7 +223,8 @@ const chips = [
         pins: {
           ICPCK: "PA3",
           ICPDA: "PA6",
-          RESET: "PA5"
+          ICVPP: "PA5",
+          ICVDD: "VDD"
         }
       }
     }
@@ -366,7 +368,8 @@ const chips = [
         pins: {
           ICPCK: "PA3",
           ICPDA: "PA6",
-          RESET: "PA5"
+          ICVPP: "PA5",
+          ICVDD: "VDD"
         }
       }
     }


### PR DESCRIPTION
The official programmer schematic uses ICVPP nomenclature instead of RESET for PA5.  (There is optional reset functionality on PA5 labled PRSTB, but that has nothing to do with the programmer).

Also, VDD is changed to various different voltages by the programmer, so it might be nice to add it as a programmer pin: ICVDD.
