### PR TITLE
Consistency with descriptions

### DIFF
--- a/src/chips.js
+++ b/src/chips.js
@@ -46,7 +46,7 @@ const chips = [
           "pull-up": ["PA7", "PA6", "PA5", "PA4", "PA3", "PA0", "PB7", "PB6", "PB5", "PB4", "PB3", "PB2", "PB1", "PB0"],
         }
       },
-      "Maximum Pin Sink/Drive Current": {
+      "Maximum Sink/Drive Current": {
         color: "#FFC869",
         pins: {
           "sink: ?": ["PA7", "PA6", "PA5", "PA4", "PA3", "PA0", "PB7", "PB6", "PB5", "PB4", "PB3", "PB2", "PB1", "PB0"],
@@ -159,7 +159,7 @@ const chips = [
           "pull-down": ["PA7", "PA6", "PA5", "PA4", "PA3", "PA0", "PB7", "PB6", "PB5", "PB4", "PB3", "PB2", "PB1", "PB0"],
         }
       },
-      "Maximum Pin Sink/Drive Current": {
+      "Maximum Sink/Drive Current": {
         color: "#FFC869",
         pins: {
           "sink: 22mA":       ["PA7", "PA6", "PA5", "PA4", "PA3", "PA0",        "PB6", "PB5",        "PB3", "PB2", "PB1", "PB0"],
@@ -281,7 +281,7 @@ const chips = [
           "pull-down":       [                                                                      "PB3", "PB2",                             "PC1", "PC0"],
         }
       },
-      "Maximum Pin Sink/Drive Current": {
+      "Maximum Sink/Drive Current": {
         color: "#FFC869",
         pins: {
           "sink: 10mA":      ["PA7", "PA6", "PA5", "PA4", "PA3", "PA0", "PB7", "PB6",               "PB3", "PB2", "PB1", "PB0",               "PC1",      ],

--- a/src/chips.js
+++ b/src/chips.js
@@ -40,13 +40,13 @@ const chips = [
       },
     ],
     data: {
-      "Pins with Pull-up / Pull-Down": {
+      "Pins with Internal Pull-up/Pull-Down": {
         color: "#FFC869",
         pins: {
           "pull-up": ["PA7", "PA6", "PA5", "PA4", "PA3", "PA0", "PB7", "PB6", "PB5", "PB4", "PB3", "PB2", "PB1", "PB0"],
         }
       },
-      "Maximum Sink/Drive Current": {
+      "Maximum Pin Sink/Drive Current": {
         color: "#FFC869",
         pins: {
           "sink: ?": ["PA7", "PA6", "PA5", "PA4", "PA3", "PA0", "PB7", "PB6", "PB5", "PB4", "PB3", "PB2", "PB1", "PB0"],
@@ -78,7 +78,7 @@ const chips = [
           "T3 PWM": ["PB7", "PB6", "PB5"],
         }
       },
-      "Comparator Inputs and Output": {
+      "Comparator Input/Output Pins": {
         color: "#BFD366",
         pins: {
           "COMP +": "PA4",
@@ -93,7 +93,7 @@ const chips = [
           INT0: ["PA0"]
         }
       },
-      "External Crystal Pins and Timer Clock Sources": {
+      "External Crystal / Timer Clock Source Pins": {
         color: "#F4D620",
         pins: {
           "T1 CLK": ["PA0",        "PA4"],
@@ -152,14 +152,14 @@ const chips = [
       },
     ],
     data: {
-      "Pins with Pull-up / Pull-Down": {
+      "Pins with Internal Pull-up/Pull-Down": {
         color: "#FFC869",
         pins: {
           "pull-up":   ["PA7", "PA6", "PA5", "PA4", "PA3", "PA0", "PB7", "PB6", "PB5", "PB4", "PB3", "PB2", "PB1", "PB0"],
           "pull-down": ["PA7", "PA6", "PA5", "PA4", "PA3", "PA0", "PB7", "PB6", "PB5", "PB4", "PB3", "PB2", "PB1", "PB0"],
         }
       },
-      "Maximum Sink/Drive Current": {
+      "Maximum Pin Sink/Drive Current": {
         color: "#FFC869",
         pins: {
           "sink: 22mA":       ["PA7", "PA6", "PA5", "PA4", "PA3", "PA0",        "PB6", "PB5",        "PB3", "PB2", "PB1", "PB0"],
@@ -193,7 +193,7 @@ const chips = [
           ADC10: "PA0",
         }
       },
-      "Comparator Inputs and Output": {
+      "Comparator Input/Output Pins": {
         color: "#BFD366",
         pins: {
           "COMP +": "PA4",
@@ -208,7 +208,7 @@ const chips = [
           INT0: ["PA0", "PB5"]
         }
       },
-      "External Crystal Pins and Timer Clock Sources": {
+      "External Crystal / Timer Clock Source Pins": {
         color: "#F4D620",
         pins: {
           "T1 CLK": ["PA0",        "PA4"],
@@ -274,14 +274,14 @@ const chips = [
       }
     ],
     data: {
-      "Pins with Pull-up / Pull-Down": {
+      "Pins with Internal Pull-up/Pull-Down": {
         color: "#FFC869",
         pins: {
           "pull-up":         ["PA7", "PA6", "PA5", "PA4", "PA3", "PA0", "PB7", "PB6", "PB5", "PB4", "PB3", "PB2", "PB1", "PB0", "PC3", "PC2", "PC1", "PC0"],
           "pull-down":       [                                                                      "PB3", "PB2",                             "PC1", "PC0"],
         }
       },
-      "Maximum Sink/Drive Current": {
+      "Maximum Pin Sink/Drive Current": {
         color: "#FFC869",
         pins: {
           "sink: 10mA":      ["PA7", "PA6", "PA5", "PA4", "PA3", "PA0", "PB7", "PB6",               "PB3", "PB2", "PB1", "PB0",               "PC1",      ],
@@ -337,7 +337,7 @@ const chips = [
           AREF: "PB1"
         }
       },
-      "Comparator Inputs and Output": {
+      "Comparator Input/Output Pins": {
         color: "#BFD366",
         pins: {
           "COMP +": "PA4",
@@ -352,7 +352,7 @@ const chips = [
           INT0: ["PA0", "PB5"]
         }
       },
-      "External Crystal Pins and Timer Clock Sources": {
+      "External Crystal / Timer Clock Source Pins": {
         color: "#F4D620",
         pins: {
           "T1 CLK": ["PA0",        "PA4"],

--- a/src/chips.js
+++ b/src/chips.js
@@ -40,13 +40,13 @@ const chips = [
       },
     ],
     data: {
-      "Pull-up / Pull-down Availability": {
+      "Pins with Pull-up / Pull-Down": {
         color: "#FFC869",
         pins: {
           "pull-up": ["PA7", "PA6", "PA5", "PA4", "PA3", "PA0", "PB7", "PB6", "PB5", "PB4", "PB3", "PB2", "PB1", "PB0"],
         }
       },
-      "Maximum current": {
+      "Maximum Sink/Drive Current": {
         color: "#FFC869",
         pins: {
           "sink: ?": ["PA7", "PA6", "PA5", "PA4", "PA3", "PA0", "PB7", "PB6", "PB5", "PB4", "PB3", "PB2", "PB1", "PB0"],
@@ -54,7 +54,7 @@ const chips = [
           // TODO: I don't understand the datasheet.
         }
       },
-      "Pins that can be set to VDD/2 (\"VDD/2 LCD Bias Voltage Generator\")": {
+      "LCD Pins (VDD/2 LCD Bias Voltage Generator)": {
         color: "#E5CDA2",
         pins: {
           "COM3": "PA4",
@@ -63,7 +63,7 @@ const chips = [
           "COM1": "PB0",
         }
       },
-      "11 bit PWM Output Pin": {
+      "11-bit PWM Output Pins": {
         color: "#26B9E4",
         pins: {
           PWM2: ["PA5", "PA4", "PA3", "PB3", "PB2"],
@@ -71,7 +71,7 @@ const chips = [
           PWM0: ["PA0", "PB5", "PB4"],
         }
       },
-      "Timer PWM Output Pin": {
+      "Timer PWM Output Pins": {
         color: "#67CEEC",
         pins: {
           "T2 PWM": ["PA3", "PB4", "PB2"],
@@ -86,7 +86,7 @@ const chips = [
           "COMP = ": "PA0"
         }
       },
-      "External Interrupt": {
+      "External Interrupt Pins": {
         color: "#FF9D07",
         pins: {
           INT1: ["PB0"],
@@ -152,14 +152,14 @@ const chips = [
       },
     ],
     data: {
-      "Pull-up / Pull-down Availability": {
+      "Pins with Pull-up / Pull-Down": {
         color: "#FFC869",
         pins: {
           "pull-up":   ["PA7", "PA6", "PA5", "PA4", "PA3", "PA0", "PB7", "PB6", "PB5", "PB4", "PB3", "PB2", "PB1", "PB0"],
           "pull-down": ["PA7", "PA6", "PA5", "PA4", "PA3", "PA0", "PB7", "PB6", "PB5", "PB4", "PB3", "PB2", "PB1", "PB0"],
         }
       },
-      "Maximum current": {
+      "Maximum Sink/Drive Current": {
         color: "#FFC869",
         pins: {
           "sink: 22mA":       ["PA7", "PA6", "PA5", "PA4", "PA3", "PA0",        "PB6", "PB5",        "PB3", "PB2", "PB1", "PB0"],
@@ -170,7 +170,7 @@ const chips = [
           "drive: 11mA/23mA": [                                          "PB7",               "PB4"                            ],
         }
       },
-      "Timer PWM Output Pin": {
+      "Timer PWM Output Pins": {
         color: "#67CEEC",
         pins: {
           "T2 PWM": ["PA3", "PB4", "PB2"],
@@ -201,7 +201,7 @@ const chips = [
           "COMP = ": "PA0"
         }
       },
-      "External Interrupt": {
+      "External Interrupt Pins": {
         color: "#FF9D07",
         pins: {
           INT1: ["PA4", "PB0"],
@@ -274,14 +274,14 @@ const chips = [
       }
     ],
     data: {
-      "Pull-up / Pull-down Availability": {
+      "Pins with Pull-up / Pull-Down": {
         color: "#FFC869",
         pins: {
           "pull-up":         ["PA7", "PA6", "PA5", "PA4", "PA3", "PA0", "PB7", "PB6", "PB5", "PB4", "PB3", "PB2", "PB1", "PB0", "PC3", "PC2", "PC1", "PC0"],
           "pull-down":       [                                                                      "PB3", "PB2",                             "PC1", "PC0"],
         }
       },
-      "Maximum current": {
+      "Maximum Sink/Drive Current": {
         color: "#FFC869",
         pins: {
           "sink: 10mA":      ["PA7", "PA6", "PA5", "PA4", "PA3", "PA0", "PB7", "PB6",               "PB3", "PB2", "PB1", "PB0",               "PC1",      ],
@@ -293,7 +293,7 @@ const chips = [
           "drive: 5mA/20mA": [                                                        "PB5", "PB4",                                                       ],
         }
       },
-      "Pins that can be set to VDD/2 (\"VDD/2 LCD Bias Voltage Generator\")": {
+      "LCD Pins (VDD/2 LCD Bias Voltage Generator)": {
         color: "#E5CDA2",
         pins: {
           "COM3": "PB5",
@@ -303,7 +303,7 @@ const chips = [
           "COM0": "PB0",
         }
       },
-      "11 bit PWM Output Pin": {
+      "11-bit PWM Output Pins": {
         color: "#26B9E4",
         pins: {
           PWM2: ["PA5",        "PA3",                      "PB5",        "PB3", "PB2",               "PC0"],
@@ -311,7 +311,7 @@ const chips = [
           PWM0: [                     "PA0",        "PB6", "PB5", "PB4",                      "PC2"],
         }
       },
-      "Timer PWM Output Pin": {
+      "Timer PWM Output Pins": {
         color: "#67CEEC",
         pins: {
           "T2 PWM": ["PA3", "PB4", "PB2"],
@@ -345,7 +345,7 @@ const chips = [
           "COMP = ": "PA0"
         }
       },
-      "External Interrupt": {
+      "External Interrupt Pins": {
         color: "#FF9D07",
         pins: {
           INT1: ["PA4", "PB0"],


### PR DESCRIPTION
This PR provides slightly better consistency in the check-box descriptions.

BEFORE:
![image](https://user-images.githubusercontent.com/670207/86631387-ad7d7700-bf93-11ea-8a52-be9b208ca5c0.png)

AFTER:
![image](https://user-images.githubusercontent.com/670207/86631239-7b6c1500-bf93-11ea-978a-cf85ffb44077.png)

We might also want to reduce the size of the sink/drive pin labels by changing `sink: 10mA, drive: 5mA` into something like `-10mA / +5mA` or even split them into two separate labels to reduce the overall size a bit.
